### PR TITLE
Subdomain scoring

### DIFF
--- a/code/data_cleaning.R
+++ b/code/data_cleaning.R
@@ -17,10 +17,10 @@ if (endsWith(current_wd, "gbv-health-provider-study")) {
   print("Got a WD that's not handled in the If-else ladder yet")
 }
 
+source(paste(gbv_project_wd, "/code/data_import.R", sep = ""))
+
 # Lint current file
 style_file(paste(gbv_project_wd, "/code/data_cleaning.R", sep = ""))
-
-source(paste(gbv_project_wd, "/code/data_import.R", sep = ""))
 
 # DATA MANAGEMENT --------------------------------------------------------------
 # Separate out key from data (key is the redcap entry form containing correct answers)

--- a/code/score.R
+++ b/code/score.R
@@ -168,7 +168,7 @@ scores <- clean_data %>%
     practice_score = rowSums(select(., all_of(pract19_clean_vars)), na.rm = FALSE)
   ) %>%
   select(
-    participant_id, time_point, attitude_general_score, attitude_acceptability_score, 
+    participant_id, time_point, attitude_general_score, attitude_acceptability_score,
     attitude_genderroles_score, attitude_profroles_score, empathy_score,
     confidence_score, practice_score
   )

--- a/code/score.R
+++ b/code/score.R
@@ -145,7 +145,10 @@ knowledge_sys_support_scores_raw <- cbind(participant_ids, knowledge_sys_support
 
 knowledge_sys_support_scores <- knowledge_sys_support_scores_raw %>%
   mutate(
-    knowledge_score = rowSums(select(., all_of(matches("knowledge"))), na.rm = TRUE),
+    knowledge_general_score = rowSums(select(., all_of(matches("knowledge_7"))), na.rm = TRUE),
+    knowledge_warning_score = rowSums(select(., all_of(matches("knowledge_8"))), na.rm = TRUE),
+    knowledge_appropriate_score = rowSums(select(., all_of(matches("knowledge_9"))), na.rm = TRUE),
+    knowledge_helpful_score = rowSums(select(., all_of(matches("knowledge_10"))), na.rm = TRUE),
     system_support_score = rowSums(select(., all_of(matches("system_support"))), na.rm = TRUE)
   ) %>%
   select(participant_id, time_point, knowledge_score, system_support_score)

--- a/code/score.R
+++ b/code/score.R
@@ -159,16 +159,17 @@ knowledge_sys_support_scores <- knowledge_sys_support_scores_raw %>%
 # Calculate scores by summing up variables for each row and bind participant IDs and timepoint
 scores <- clean_data %>%
   mutate(
-    attitude_general_score = rowSums(select(., all_of(matches("attitudes_11")), na.rm = TRUE),
-    attitude_acceptability_score = rowSums(select(., all_of(matches("attitudes_12")), na.rm = TRUE),
-    attitude_genderroles_score = rowSums(select(., all_of(matches("attitudes_13")), na.rm = TRUE),
-    attitude_profroles_score = rowSums(select(., all_of(matches("attitudes_14")), na.rm = TRUE),
+    attitude_general_score = rowSums(select(., all_of(matches("attitudes_11"))), na.rm = TRUE),
+    attitude_acceptability_score = rowSums(select(., all_of(matches("attitudes_12"))), na.rm = TRUE),
+    attitude_genderroles_score = rowSums(select(., all_of(matches("attitudes_13"))), na.rm = TRUE),
+    attitude_profroles_score = rowSums(select(., all_of(matches("attitudes_14"))), na.rm = TRUE),
     empathy_score = rowSums(select(., all_of(empathy_vars)), na.rm = TRUE),
     confidence_score = rowSums(select(., all_of(conf_vars)), na.rm = TRUE),
     practice_score = rowSums(select(., all_of(pract19_clean_vars)), na.rm = FALSE)
   ) %>%
   select(
-    participant_id, time_point, attitude_score, empathy_score,
+    participant_id, time_point, attitude_general_score, attitude_acceptability_score, 
+    attitude_genderroles_score, attitude_profroles_score, empathy_score,
     confidence_score, practice_score
   )
 

--- a/code/score.R
+++ b/code/score.R
@@ -149,17 +149,23 @@ knowledge_sys_support_scores <- knowledge_sys_support_scores_raw %>%
     knowledge_warning_score = rowSums(select(., all_of(matches("knowledge_8"))), na.rm = TRUE),
     knowledge_appropriate_score = rowSums(select(., all_of(matches("knowledge_9"))), na.rm = TRUE),
     knowledge_helpful_score = rowSums(select(., all_of(matches("knowledge_10"))), na.rm = TRUE),
-    system_support_score = rowSums(select(., all_of(matches("system_support"))), na.rm = TRUE)
+    system_support_score = rowSums(select(., all_of(matches("system_support"))), na.rm = TRUE),
   ) %>%
-  select(participant_id, time_point, knowledge_score, system_support_score)
+  select(
+    participant_id, time_point, knowledge_general_score, knowledge_warning_score,
+    knowledge_appropriate_score, knowledge_helpful_score, system_support_score
+  )
 
 #' Sum attitudes scores and bind participant IDs and timepoint
 attitudes_sum <- c(att_vars, att12_vars)
 
-# Calculate scores by summing up variables for each row
+# Calculate scores by summing up variables for each row and bind participant IDs and timepoint
 scores <- clean_data %>%
   mutate(
-    attitude_score = rowSums(select(., all_of(attitudes_sum)), na.rm = TRUE),
+    attitude_general_score = rowSums(select(., all_of(matches("attitudes_11")), na.rm = TRUE),
+    attitude_acceptability_score = rowSums(select(., all_of(matches("attitudes_12")), na.rm = TRUE),
+    attitude_genderroles_score = rowSums(select(., all_of(matches("attitudes_13")), na.rm = TRUE),
+    attitude_profroles_score = rowSums(select(., all_of(matches("attitudes_14")), na.rm = TRUE),
     empathy_score = rowSums(select(., all_of(empathy_vars)), na.rm = TRUE),
     confidence_score = rowSums(select(., all_of(conf_vars)), na.rm = TRUE),
     practice_score = rowSums(select(., all_of(pract19_clean_vars)), na.rm = FALSE)

--- a/code/score.R
+++ b/code/score.R
@@ -156,9 +156,6 @@ knowledge_sys_support_scores <- knowledge_sys_support_scores_raw %>%
     knowledge_appropriate_score, knowledge_helpful_score, system_support_score
   )
 
-#' Sum attitudes scores and bind participant IDs and timepoint
-attitudes_sum <- c(att_vars, att12_vars)
-
 # Calculate scores by summing up variables for each row and bind participant IDs and timepoint
 scores <- clean_data %>%
   mutate(

--- a/code/table_scores.R
+++ b/code/table_scores.R
@@ -34,19 +34,20 @@ scores_summary_table <- clean_scores %>%
   select(-participant_id) %>%
   tbl_summary(
     by = time_point,
-    type = c(system_support_score, practice_score) ~ "continuous",
+    type = c(system_support_score, practice_score, knowledge_warning_score, 
+             knowledge_appropriate_score) ~ "continuous",
     label = list(
-      knowledge_general_score ~ "General knowledge",
-      knowledge_warning_score ~ "Warning signs",
-      knowledge_appropriate_score ~ "Appropriate ways to ask about GBV",
-      knowledge_helpful_score ~ "Helpful responses to support a woman subjected to GBV",
-      system_support_score ~ "System support",
-      attitude_general_score ~ "General attitudes towards GBV and the health provider role",
-      attitude_acceptability_score ~ "Acceptability for a man to hit his partner",
-      attitude_genderroles_score ~ "Attitudes towards gender roles",
-      attitude_profroles_score ~ "Attitudes towards professional roles",
-      empathy_score ~ "Empathy",
-      confidence_score ~ "Confidence",
+      knowledge_general_score ~ "General knowledge (44)",
+      knowledge_warning_score ~ "Warning signs (21)",
+      knowledge_appropriate_score ~ "Appropriate ways to ask about GBV (12)",
+      knowledge_helpful_score ~ "Helpful responses to support a woman subjected to GBV (23)",
+      system_support_score ~ "System support (6)",
+      attitude_general_score ~ "General attitudes towards GBV and the health provider role (34)",
+      attitude_acceptability_score ~ "Acceptability for a man to hit his partner (24)",
+      attitude_genderroles_score ~ "Attitudes towards gender roles (21)",
+      attitude_profroles_score ~ "Attitudes towards professional roles (21)",
+      empathy_score ~ "Empathy (16)",
+      confidence_score ~ "Confidence (10)",
       practice_score ~ "Practice"
     ),
     statistic = list(

--- a/code/table_scores.R
+++ b/code/table_scores.R
@@ -48,7 +48,7 @@ scores_summary_table <- clean_scores %>%
       attitude_profroles_score ~ "Attitudes towards professional roles (21)",
       empathy_score ~ "Empathy (16)",
       confidence_score ~ "Confidence (10)",
-      practice_score ~ "Practice"
+      practice_score ~ "Practice (9)"
     ),
     statistic = list(
       all_continuous() ~ "{mean} ({sd})"

--- a/code/table_scores.R
+++ b/code/table_scores.R
@@ -36,9 +36,15 @@ scores_summary_table <- clean_scores %>%
     by = time_point,
     type = c(system_support_score, practice_score) ~ "continuous",
     label = list(
-      knowledge_score ~ "Knowledge",
+      knowledge_general_score ~ "General knowledge",
+      knowledge_warning_score ~ "Warning signs",
+      knowledge_appropriate_score ~ "Appropriate ways to ask about GBV",
+      knowledge_helpful_score ~ "Helpful responses to support a woman subjected to GBV",
       system_support_score ~ "System support",
-      attitude_score ~ "Attitude",
+      attitude_general_score ~ "General attitudes towards GBV and the health provider role",
+      attitude_acceptability_score ~ "Acceptability for a man to hit his partner",
+      attitude_genderroles_score ~ "Attitudes towards gender roles",
+      attitude_profroles_score ~ "Attitudes towards professional roles",
       empathy_score ~ "Empathy",
       confidence_score ~ "Confidence",
       practice_score ~ "Practice"


### PR DESCRIPTION
1. Updated the score.r script to:
- sum the knowledge and attitude subdomains instead of the overall knowledge and attitude scores
- removed an unnecessary vector for attitude scoring

Note: I did not remove this, but do we actually need the section titled, "# CREATE SUB-DOMAINS" now? Given how I coded the summing of scores, I was uncertain if there was any reason we needed to keep the subdomain vectors. We can always discuss Monday, was just curious.

2. Updated the table_scores.R script to include the knowledge and attitude subdomains instead of the overall scores. The script runs, but something is off with the table (it has numbers under warning signs, for example, and I'm not sure why). Need to investigate more on this!