### PR TITLE
Reorganized participant id cleaning

### DIFF
--- a/code/data_cleaning.R
+++ b/code/data_cleaning.R
@@ -75,9 +75,6 @@ data <- data %>%
 data <- data %>%
   mutate(municipality = str_to_title(municipality))
 
-## Clean all the PIDs
-source(paste(gbv_project_wd, "/code/participant_id_cleaning.R", sep = ""))
-
 # Clean up demographic data
 data <- data %>%
   mutate(sex_factored = factor(sex,
@@ -118,10 +115,6 @@ data <- data %>%
     position_years > 99, 2021 - position_years, position_years
   )) %>%
   select(-matches("fup"))
-
-# drop participant 11 due to having only post tests
-# (388 to 386 rows) removes 2 rows
-data <- data[data$participant_id != 11, ]
 
 # create an actual date column
 data$date_as_date_format <- ifelse(is.na(data$date), NA,
@@ -192,5 +185,5 @@ data <- data %>%
   select(-starts_with("practices_19"))
 
 # Write data to folder
-path_to_clean_rds <- paste(gbv_project_wd, "/data/clean/gbv_data_clean.RDS", sep = "")
+path_to_clean_rds <- paste(gbv_project_wd, "/data/clean/gbv_data_interim_clean.RDS", sep = "")
 saveRDS(data, file = path_to_clean_rds)

--- a/code/participant_id_cleaning.R
+++ b/code/participant_id_cleaning.R
@@ -17,6 +17,11 @@ if (endsWith(current_wd, "gbv-health-provider-study")) {
   print("Got a WD that's not handled in the If-else ladder yet")
 }
 
+source(paste(gbv_project_wd, "/code/data_cleaning.R", sep = ""))
+
+path_to_imterim_clean_rds <- paste(gbv_project_wd, "/data/clean/gbv_data_interim_clean.RDS", sep = "")
+data <- readRDS(path_to_imterim_clean_rds)
+
 # Lint current file
 style_file(paste(gbv_project_wd, "/code/participant_id_cleaning.R", sep = ""))
 
@@ -161,8 +166,16 @@ data <- data %>%
   select(-participant_id) %>%
   rename(participant_id = data_id)
 
+# drop participant 11 due to having only post tests
+# (388 to 386 rows) removes 2 rows
+data <- data[data$participant_id != 11, ]
+
 columns_to_move <- c("participant_id", "participant_id_original", "time_point")
 
 # Rearrange columns
 data <- data %>%
   select(all_of(columns_to_move), everything())
+
+# Write data to folder
+path_to_clean_rds <- paste(gbv_project_wd, "/data/clean/gbv_data_clean.RDS", sep = "")
+saveRDS(data, file = path_to_clean_rds)

--- a/code/score.R
+++ b/code/score.R
@@ -18,15 +18,15 @@ if (endsWith(current_wd, "gbv-health-provider-study")) {
   print("Got a WD that's not handled in the If-else ladder yet")
 }
 
-source(paste(gbv_project_wd, "/code/data_cleaning.R", sep = ""))
-source(paste(gbv_project_wd, "/code/dependencies.R", sep = ""))
-
 style_file(paste(gbv_project_wd, "/code/score.R", sep = ""))
 
+source(paste(gbv_project_wd, "/code/participant_id_cleaning.R", sep = ""))
+path_to_clean_rds <- paste(gbv_project_wd, "/data/clean/gbv_data_clean.RDS", sep = "")
 clean_data <- readRDS(path_to_clean_rds)
 
 answers <- clean_data %>%
   select(participant_id, matches("knowledge|attitudes|system_support|confidence|empathy|practices"))
+
 
 key_only <- key %>%
   select(matches("knowledge|attitudes|system_support|confidence|empathy|practices"))

--- a/code/table_scores.R
+++ b/code/table_scores.R
@@ -34,8 +34,10 @@ scores_summary_table <- clean_scores %>%
   select(-participant_id) %>%
   tbl_summary(
     by = time_point,
-    type = c(system_support_score, practice_score, knowledge_warning_score, 
-             knowledge_appropriate_score) ~ "continuous",
+    type = c(
+      system_support_score, practice_score, knowledge_warning_score,
+      knowledge_appropriate_score
+    ) ~ "continuous",
     label = list(
       knowledge_general_score ~ "General knowledge (44)",
       knowledge_warning_score ~ "Warning signs (21)",


### PR DESCRIPTION
Reorganized the cleaning scripts so that now you can independently source either data_cleaning.R or participant_id_cleaning.R. data_cleaning.R now writes out an interim dataset that the participant id cleaning script picks up to clean just the participant IDs. We can keep all of the overall cleaning in the data_cleaning script and only write participant ID cleaning in the participant id script.

Closes #21 